### PR TITLE
Fix typo in TypeScript Union Type post

### DIFF
--- a/src/pages/posts/typescript-union-type-a-deeper-look.md
+++ b/src/pages/posts/typescript-union-type-a-deeper-look.md
@@ -102,7 +102,7 @@ The bottom line will throw an error stating it can't set the value to `offline` 
 
 A union type is only available at compile-time, meaning we can't loop over the values.
 
-LEt's say we need the array of all possible status values we just defined.
+Let's say we need the array of all possible status values we just defined.
 
 Normally we would try something like this:
 


### PR DESCRIPTION
Change LEt's to Let's under "Union type limitations" section