### PR TITLE
Fixed Typo from Grid to Flex

### DIFF
--- a/src/pages/posts/center-elements-with-tailwind-css.md
+++ b/src/pages/posts/center-elements-with-tailwind-css.md
@@ -54,7 +54,7 @@ Let's see how that would look like:
 
 ```html
 <div class="flex items-center justify-center h-screen">
-  Centered using Tailwind Grid
+  Centered using Tailwind Flex
 </div>
 ```
 


### PR DESCRIPTION
In the "Tailwind center div with flex center" section, there was a typo in the code. The content of the code was showing that it was centered with a grid, although it was implemented with flex.